### PR TITLE
Bugfix: Replace hardcoded function name in Domain UseCaseProvider.

### DIFF
--- a/{{cookiecutter.app_name}}/Platform/UseCases/UseCaseProvider.swift
+++ b/{{cookiecutter.app_name}}/Platform/UseCases/UseCaseProvider.swift
@@ -18,7 +18,7 @@ public final class UseCaseProvider: Domain.UseCaseProvider {
 
     public func make{{cookiecutter.domain_model}}sUseCase() -> Domain.{{cookiecutter.domain_model}}sUseCase {
         {{cookiecutter.domain_model}}sUseCase(
-            repository: repositoryProvider.makePostsRepository()
+    repository: repositoryProvider.make{{cookiecutter.domain_model}}sRepository()
         )
     }
 }


### PR DESCRIPTION
This PR resolves an issue where the current template contains a hardcoded call to a function name, **makePostsRepository**, rather than **{{cookiecutter.domain_model}}**.